### PR TITLE
Quick devlog fix

### DIFF
--- a/public/text_files/2024_08_16_0.txt
+++ b/public/text_files/2024_08_16_0.txt
@@ -1,7 +1,7 @@
-2024.11.01;
-2024.08.16;
-[Creating the Website] Devlog #1: Hello World!;
-Website introduction and overview of the devlogs section.;
+2025.06.19
+2024.08.16
+[Creating the Website] Devlog #1: Hello World!
+Website introduction and overview of the devlogs section.
 ## >> Intro
 
 Hello, and welcome to my website.

--- a/public/text_files/2024_08_16_1.txt
+++ b/public/text_files/2024_08_16_1.txt
@@ -1,7 +1,7 @@
-2024.11.01;
-2024.08.16;
-[Creating the Website] Devlog #2: Continued Progress on the Website;
-Website progress and overview of the rest of the sections.;
+2025.06.19
+2024.08.16
+[Creating the Website] Devlog #2: Continued Progress on the Website
+Website progress and overview of the rest of the sections.
 ## >> Hello!
 
 Welcome back to the next devlog!

--- a/public/text_files/2024_10_23_0.txt
+++ b/public/text_files/2024_10_23_0.txt
@@ -1,7 +1,7 @@
-2024.11.06;
-2024.10.23;
-[Plate Rush!] Devlog #1: Conveyor Belts and Items;
-I talk about my in-progress game idea and mainly about my implementation of the conveyor belt.;
+2025.06.19
+2024.10.23
+[Plate Rush!] Devlog #1: Conveyor Belts and Items
+I talk about my in-progress game idea and mainly about my implementation of the conveyor belt.
 ## >> The Game!
 
 This is the first devlog for my game made with [Pixelbox](https://pixwlk.itch.io/pixelbox). I decided that *Plate Rush!* is the title of the game, although I realize now that it sounds quite close to *PlateUp!*. If I find a better name then I'll change it.

--- a/public/text_files/2024_11_06_0.txt
+++ b/public/text_files/2024_11_06_0.txt
@@ -1,7 +1,7 @@
-2024.12.03;
-2024.11.06;
-[Plate Rush! -> Plate, Rush, Serve!] Devlog #2: Customers / Fixing Items / Published!;
-I talk about the customers and how I store items differently.;
+2025.06.19
+2024.11.06
+[Plate Rush! -> Plate, Rush, Serve!] Devlog #2: Customers / Fixing Items / Published!
+I talk about the customers and how I store items differently.
 ## >> Game Published!
 
 Hello everyone! The game, *Plate Rush!* has been renamed to, *Plate, Rush, Serve!* Adding the third word in the title made it sound more like a countdown. Plate... Rush... SERVE!

--- a/public/text_files/2024_12_01_0.txt
+++ b/public/text_files/2024_12_01_0.txt
@@ -1,7 +1,7 @@
-2024.12.03;
-2024.12.01;
-[Creating the Website] Devlog #3: Revamp the Website;
-I removed a page, and components now move based on the width of the screen.;
+2025.06.19
+2024.12.01
+[Creating the Website] Devlog #3: Revamp the Website
+I removed a page, and components now move based on the width of the screen.
 ## >> Short Devlog
 Hello and welcome back to another devlog. I worked on the website again to change it up.
 

--- a/public/text_files/2025_06_08_0.txt
+++ b/public/text_files/2025_06_08_0.txt
@@ -1,7 +1,7 @@
-2025.06.10;
-2025.06.08;
-[Devlogs Maker] #1: Posting from the App;
-I can use the application as an easier way of creating a devlog, because the post doesn't have to be formatted manually.;
+2025.06.19
+2025.06.08
+[Devlogs Maker] #1: Posting from the App
+I can use the application as an easier way of creating a devlog, because the post doesn't have to be formatted manually.
 ## >> Intro
 
 Hello everyone, I finally completed the basic features for my app "Devlogs Maker". The devlog you see here will be posted from there. I would like to think of a better name for it but it is what it is. There are definitely a few bugs to iron out, but the main features work (mostly) as expected.

--- a/public/text_files/2025_06_17_0.txt
+++ b/public/text_files/2025_06_17_0.txt
@@ -1,7 +1,7 @@
-2025.06.17;
-2025.06.17;
-[Devlogs Maker] #2: Brief Overview of Basic Features;
-The minimum features in the app so far can: post devlogs; get devlogs & edit them; & delete devlogs. Import formatted devlogs & export them to system. Clear text for a clean slate. Verify/refresh tokens for user.;
+2025.06.19
+2025.06.17
+[Devlogs Maker] #2: Brief Overview of Basic Features
+The minimum features in the app so far can: post devlogs; get devlogs & edit them; & delete devlogs. Import formatted devlogs & export them to system. Clear text for a clean slate. Verify/refresh tokens for user.
 ## >> Intro
 
 Hi everyone, I'm going to get to the basic features (suppose this is a MVP) of Devlogs Maker. I went over the basic process in my [last devlog](https://jennyton88.github.io/devlogs/log/2025_06_08_0).

--- a/src/components/LogSummary.jsx
+++ b/src/components/LogSummary.jsx
@@ -10,7 +10,7 @@ function parseLogData(text_data) {
 
     var curr_index = 0;
     for (let i = 0; i < line_length; i++) {
-        curr_index = text_data.indexOf(";", curr_index + 1);
+        curr_index = text_data.indexOf('\n', curr_index + 1);
         indexes.push(curr_index);
     }
 
@@ -19,7 +19,6 @@ function parseLogData(text_data) {
         creation_date: text_data.substring(indexes[0] + 1, indexes[1]),
         title: text_data.substring(indexes[1] + 1, indexes[2]),
         summary: text_data.substring(indexes[2] + 1, indexes[3]),
-        body: text_data.substring(indexes[3] + 1 ),
     };
 }
 

--- a/src/pages/Log.jsx
+++ b/src/pages/Log.jsx
@@ -11,7 +11,7 @@ function parseLogText(text_data) {
 
     var curr_index = 0;
     for (let i = 0; i < line_length; i++) {
-        curr_index = text_data.indexOf(";", curr_index + 1);
+        curr_index = text_data.indexOf("\n", curr_index + 1);
         indexes.push(curr_index);
     }
 
@@ -19,7 +19,6 @@ function parseLogText(text_data) {
         edit_date: text_data.substring(0, indexes[0]),
         creation_date: text_data.substring(indexes[0] + 1, indexes[1]),
         title: text_data.substring(indexes[1] + 1, indexes[2]),
-        summary: text_data.substring(indexes[2] + 1, indexes[3]),
         body: text_data.substring(indexes[3] + 1 ),
     };
 }


### PR DESCRIPTION
# What changed

Refer to #25 

- Update how devlogs are formatted
  - The first 4 lines for date edited / created, title, and summary are separated by '\n' not ';'. There was no need for multiline summaries or titles, so this can be changed as a result.
- Edited devlogs to remove the ';' endings.
- Removed returning summary and body where they were not needed